### PR TITLE
new major version to target Microsoft.Extensions.Logging 5.x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,12 +15,12 @@ workflows:
       - build-test-linux:
           name: .NET Core 3.1 - Linux
           docker-image: mcr.microsoft.com/dotnet/core/sdk:3.1-focal
-          build-target-framework: netcoreapp3.1
+          build-target-framework: netstandard2.1
           test-target-framework: netcoreapp3.1
       - build-test-linux:
           name: .NET 5.0 - Linux
           docker-image: mcr.microsoft.com/dotnet/sdk:5.0-focal
-          build-target-framework: netcoreapp3.1
+          build-target-framework: netstandard2.1
           test-target-framework: net5.0
       - build-test-windows:
           name: .NET Framework 4.6.1 - Windows

--- a/.ldrelease/config.yml
+++ b/.ldrelease/config.yml
@@ -10,8 +10,8 @@ circleci:
 template:
   name: dotnet-windows
   env:
-    LD_RELEASE_TEST_TARGET_FRAMEWORK: netcoreapp3.1
-    LD_RELEASE_DOCS_TARGET_FRAMEWORK: netcoreapp3.1
+    LD_RELEASE_TEST_TARGET_FRAMEWORK: netstandard2.1
+    LD_RELEASE_DOCS_TARGET_FRAMEWORK: netstandard2.1
 
 documentation:
   title: LaunchDarkly Logging API for .NET - Microsoft.Extensions.Logging Adapter

--- a/README.md
+++ b/README.md
@@ -12,14 +12,14 @@ For more information and examples, see the [API documentation](https://launchdar
 
 ## Supported .NET versions
 
-The 1.x version of the package, which references `Microsoft.Extensions.Logging` version 3.x, is built for two target frameworks (the only ones where `Microsoft.Extensions.Logging` 3.x is available):
+The 2.x version of the package, which references `Microsoft.Extensions.Logging` version 5.x, is built for two target frameworks:
 
-* .NET Core 3.1: runs in .NET Core 3.1 and above, or in .NET 5.0 and above.
-* .NET Standard 2.0: runs in .NET Core 2.x, or in .NET Framework 4.6.1 and above, or in library code that is targeted to .NET Standard 2.x.
+* .NET Standard 2.1: runs in .NET Core 3.1 and above, or in .NET 5.0 and above, or in library code that is targeted to .NET Standard 2.1 and above.
+* .NET Standard 2.0: runs in .NET Core 2.x, or in .NET Framework 4.6.1 and above, or in library code that is targeted to .NET Standard 2.0.
 
 The .NET build tools should automatically load the most appropriate build of the library for whatever platform your application or library is targeted to.
 
-Higher major versions of `LaunchDarkly.Logging.Microsoft` can be used with later versions of `Microsoft.Extensions.Logging`.
+New versions of `LaunchDarkly.Logging.Microsoft` will be released as necessary to support higher versions of `Microsoft.Extensions.Logging` as they become available.
 
 ## Contributing
 

--- a/docs-src/index.md
+++ b/docs-src/index.md
@@ -6,7 +6,7 @@ The [`LaunchDarkly.Logging`](https://launchdarkly.github.io/dotnet-logging/) als
 
 ## Usage
 
-The **<xref:LaunchDarkly.Logging.LdMicrosoftLogging>** adapter is provided by the NuGet package [**`LaunchDarkly.Logging.Microsoft`**](https://nuget.org/packages/LaunchDarkly.Logging.Microsoft). Version 1.x of the package works with `Microsoft.Extensions.Logging` version 3.x. Higher major versions of the package can be used with later versions of `Microsoft.Extensions.Logging`.
+The **<xref:LaunchDarkly.Logging.LdMicrosoftLogging>** adapter is provided by the NuGet package [**`LaunchDarkly.Logging.Microsoft`**](https://nuget.org/packages/LaunchDarkly.Logging.Microsoft). Version 2.x of the package works with `Microsoft.Extensions.Logging` version 5.x. New versions of `LaunchDarkly.Logging.Microsoft` will be released as necessary to support higher versions of `Microsoft.Extensions.Logging` as they become available.
 
 Like `LaunchDarkly.Logging`, `Microsoft.Extensions.Logging` is a facade that can delegate to various destinations. These are configured with the [`LoggerFactory`](https://docs.microsoft.com/en-us/dotnet/api/microsoft.extensions.logging.loggerfactory?view=dotnet-plat-ext-5.0) or by dependency injection mechanisms that provide an `ILoggerFactory`. 
 

--- a/src/LaunchDarkly.Logging.Microsoft/LaunchDarkly.Logging.Microsoft.csproj
+++ b/src/LaunchDarkly.Logging.Microsoft/LaunchDarkly.Logging.Microsoft.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0</Version>
+    <Version>2.0.0-alpha.1</Version>
       <!--
       The reason there's a mechanism here for overriding the target frameworks with
       an environment variable is that we want to be able to run CI tests using older
       SDKs which do not consider "net5.0" to be a valid target framework that can be
       referenced in a project file.
     -->
-    <BuildFrameworks Condition="'$(BUILDFRAMEWORKS)' == ''">netstandard2.0;netcoreapp3.1</BuildFrameworks>
+    <BuildFrameworks Condition="'$(BUILDFRAMEWORKS)' == ''">netstandard2.0;netstandard2.1</BuildFrameworks>
     <TargetFrameworks>$(BUILDFRAMEWORKS)</TargetFrameworks>
 
     <DebugType>portable</DebugType>
@@ -28,7 +28,7 @@
 
   <ItemGroup>
     <PackageReference Include="LaunchDarkly.Logging" Version="[1.0.1,]" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="[3.0.0,5.0.0)" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="[5.0.0,6.0.0)" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">

--- a/test/LaunchDarkly.Logging.Microsoft.Tests/LaunchDarkly.Logging.Microsoft.Tests.csproj
+++ b/test/LaunchDarkly.Logging.Microsoft.Tests/LaunchDarkly.Logging.Microsoft.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TestFramework Condition="'$(TESTFRAMEWORK)' == ''">netcoreapp3.1</TestFramework>
+    <TestFramework Condition="'$(TESTFRAMEWORK)' == ''">netcoreapp2.1</TestFramework>
     <TargetFramework>$(TESTFRAMEWORK)</TargetFramework>
     <AssemblyName>LaunchDarkly.Logging.Microsoft.Tests</AssemblyName>
   </PropertyGroup>


### PR DESCRIPTION
This updates the dependency on `Microsoft.Extensions.Logging` to the latest stable major version, 5.x. We will release this as version 2.0 of `LaunchDarkly.Logging.Microsoft`. The previous release is now on a 1.x maintenance branch. The implementation is the same because the subset of the M.E.L API that we're using didn't have any breaking changes.

As is often the case in .NET, target framework compatibility may be a bit confusing. The previous release had target frameworks of .NET Standard 2.0 and .NET Core 3.1, because those were the available target frameworks for M.E.L. In hindsight, the .NET Core 3.1 one was probably unnecessary because a .NET Core 3.1 app can use .NET Standard 2.0 libraries (and would still automatically load the .NET Core 3.1 version of M.E.L itself). I've changed the targets to .NET Standard 2.0 and .NET Standard 2.1, because 2.1 is what .NET 5.0 is compatible with. And .NET Framework 4.6.1 will continue using .NET Standard 2.0. Basically, the only platform that can't use this is .NET Framework 4.5.2; M.E.L has never been available for that.

M.E.L 6.0 is currently in [preview release](https://www.nuget.org/packages/Microsoft.Extensions.Logging/6.0.0-preview.3.21201.4). Once there's a GA release, we'll put out another version of this with an updated dependency version and any necessary API changes. It's possible that 6.0 won't have any breaking changes from 5.0, but I think it is still better to depend specifically on 5.x here rather than leaving the dependency completely open, because it's a bit easier to handle transitive dependency conflicts .NET if the major versions to be consistent— and, prior to the 6.0 GA, we can't really be sure that it is in fact backward-compatible.

For further discussion, see https://github.com/launchdarkly/dotnet-logging/issues/6.