### PR TITLE
[WIP] add compatibility with Microsoft.Extensions.Logging 6.0

### DIFF
--- a/src/LaunchDarkly.Logging.Microsoft/LaunchDarkly.Logging.Microsoft.csproj
+++ b/src/LaunchDarkly.Logging.Microsoft/LaunchDarkly.Logging.Microsoft.csproj
@@ -28,7 +28,7 @@
 
   <ItemGroup>
     <PackageReference Include="LaunchDarkly.Logging" Version="[1.0.1,]" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="[5.0.0,6.0.0)" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0-preview.3.21201.4" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">


### PR DESCRIPTION
This is a draft PR because as of right now, there's not yet a 6.0.0 GA release of [Microsoft.Extensions.Logging](https://www.nuget.org/packages/Microsoft.Extensions.Logging). Until there is, we can't be sure that it is backward-compatible enough with 5.0 for our same adapter implementation to work, but we can test against the latest preview version.

Once there is a 6.0.0 GA release, if it is _not_ backward-compatible with 5.x, then we'll need to change the M.E.L dependency here to `[6.0.0,7.0.0)` and release a 3.0.0 version of our package (creating a 2.x maintenance branch off of master).

If 6.0.0 _is_ backward-compatible with 5.x, then we have two options:

1. Change the M.E.L dependency here to `[5.0.0,7.0.0)` and release a new 2.x minor version of our package. 
2. Do the same as above. In other words, each major version of our package will target only one major version of theirs, even if theoretically ours could work with more than one of theirs.

The theoretical reason why option 2 might be best in that case has to do with transitive dependencies. Suppose that we release 2.1.0 of our package with a dependency range of `[5.0.0,7.0.0)`. I believe that installing our package will by default select version 5.0.0 of M.E.L, rather than the latest compatible version. If the host application is using version 6.0.0, .NET could consider this to be a version conflict, and .NET Framework will require a binding redirect (although it might anyway, even for two different 5.x versions). .NET Core is normally more graceful than this and can resolve many conflicts automatically, but I think that may not work if the major versions are different.

Anyway, at present there are no code changes required but we'll need to revisit this after Microsoft puts out 6.0.0.