### PR TITLE
update for v6.x of MS package

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,10 +8,6 @@ workflows:
   test:
     jobs:
       - build-test-linux:
-          name: .NET Core 2.1 - Linux
-          docker-image: mcr.microsoft.com/dotnet/core/sdk:2.1-focal
-          build-target-framework: netstandard2.0
-          test-target-framework: netcoreapp2.1
       - build-test-linux:
           name: .NET Core 3.1 - Linux
           docker-image: mcr.microsoft.com/dotnet/core/sdk:3.1-focal

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,6 @@ workflows:
   test:
     jobs:
       - build-test-linux:
-      - build-test-linux:
           name: .NET Core 3.1 - Linux
           docker-image: mcr.microsoft.com/dotnet/core/sdk:3.1-focal
           build-target-framework: netstandard2.1

--- a/.ldrelease/config.yml
+++ b/.ldrelease/config.yml
@@ -18,4 +18,5 @@ documentation:
 
 branches:
   - name: master
+  - name: 2.x
   - name: 1.x

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ For more information and examples, see the [API documentation](https://launchdar
 The 3.x version of the package, which references `Microsoft.Extensions.Logging` version 6.x, is built for two target frameworks:
 
 * .NET Standard 2.1: runs in .NET Core 3.1 and above, or in .NET 5.0 and above, or in library code that is targeted to .NET Standard 2.1 and above.
-* .NET Standard 2.0: runs in .NET Core 2.x, or in .NET Framework 4.6.1 and above, or in library code that is targeted to .NET Standard 2.0.
+* .NET Standard 2.0: runs in .NET Framework 4.6.1 and above, or in library code that is targeted to .NET Standard 2.0.
 
 The .NET build tools should automatically load the most appropriate build of the library for whatever platform your application or library is targeted to.
 

--- a/README.md
+++ b/README.md
@@ -12,12 +12,14 @@ For more information and examples, see the [API documentation](https://launchdar
 
 ## Supported .NET versions
 
-The 2.x version of the package, which references `Microsoft.Extensions.Logging` version 5.x, is built for two target frameworks:
+The 3.x version of the package, which references `Microsoft.Extensions.Logging` version 6.x, is built for two target frameworks:
 
 * .NET Standard 2.1: runs in .NET Core 3.1 and above, or in .NET 5.0 and above, or in library code that is targeted to .NET Standard 2.1 and above.
 * .NET Standard 2.0: runs in .NET Core 2.x, or in .NET Framework 4.6.1 and above, or in library code that is targeted to .NET Standard 2.0.
 
 The .NET build tools should automatically load the most appropriate build of the library for whatever platform your application or library is targeted to.
+
+The 2.x version of `LaunchDarkly.Logging.Microsoft` is for use with `Microsoft.Extensions.Logging` version 5.x, and is functionally identical otherwise.
 
 New versions of `LaunchDarkly.Logging.Microsoft` will be released as necessary to support higher versions of `Microsoft.Extensions.Logging` as they become available.
 

--- a/src/LaunchDarkly.Logging.Microsoft/LaunchDarkly.Logging.Microsoft.csproj
+++ b/src/LaunchDarkly.Logging.Microsoft/LaunchDarkly.Logging.Microsoft.csproj
@@ -29,7 +29,7 @@
 
   <ItemGroup>
     <PackageReference Include="LaunchDarkly.Logging" Version="[1.0.1,]" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="[5.0.0,6.0.0)" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="[6.0.0,7.0.0)" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">


### PR DESCRIPTION
We'll release this as a new major version of `dotnet-logging-adapter-ms`.

This also removes .NET Core 2.1 from the CI build, because .NET Core 2.1 is now EOL. The target frameworks we build this package for are still .NET Standard 2.0 and 2.1.

See: https://github.com/launchdarkly/dotnet-logging-adapter-ms/pull/3

