### PR TITLE
Changes to upgrade to Microsoft.Logging.Extensions v7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,15 +8,10 @@ workflows:
   test:
     jobs:
       - build-test-linux:
-          name: .NET Core 3.1 - Linux
-          docker-image: mcr.microsoft.com/dotnet/core/sdk:3.1-focal
+          name: .NET 7.0 - Linux
+          docker-image: mcr.microsoft.com/dotnet/sdk:7.0-focal
           build-target-framework: netstandard2.1
-          test-target-framework: netcoreapp3.1
-      - build-test-linux:
-          name: .NET 5.0 - Linux
-          docker-image: mcr.microsoft.com/dotnet/sdk:5.0-focal
-          build-target-framework: netstandard2.1
-          test-target-framework: net5.0
+          test-target-framework: net7.0
       - build-test-windows:
           name: .NET Framework 4.6.1 - Windows
           build-target-framework: netstandard2.0

--- a/.ldrelease/config.yml
+++ b/.ldrelease/config.yml
@@ -9,7 +9,7 @@ jobs:
     template:
       name: dotnet-linux
     env:
-      LD_RELEASE_TEST_TARGET_FRAMEWORK: net5.0
+      LD_RELEASE_TEST_TARGET_FRAMEWORK: net7.0
       LD_RELEASE_DOCS_TARGET_FRAMEWORK: netstandard2.1
 
 documentation:
@@ -18,5 +18,6 @@ documentation:
 
 branches:
   - name: master
+  - name: 3.x
   - name: 2.x
   - name: 1.x

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,8 +44,8 @@ To run all unit tests, for all targets:
 dotnet test
 ```
 
-Or, to run tests only for the .NET Standard 2.0 target (using the .NET Core 2.1 runtime):
+Or, to run tests only for the .NET Standard 2.0 target (using the .NET Core 7 runtime):
 
 ```
-dotnet test -f netcoreapp2.1
+dotnet test -f net7.0
 ```

--- a/README.md
+++ b/README.md
@@ -12,12 +12,14 @@ For more information and examples, see the [API documentation](https://launchdar
 
 ## Supported .NET versions
 
-The 3.x version of the package, which references `Microsoft.Extensions.Logging` version 6.x, is built for two target frameworks:
+The 4.x version of the package, which references `Microsoft.Extensions.Logging` version 7.x, is built for two target frameworks:
 
 * .NET Standard 2.1: runs in .NET Core 3.1 and above, or in .NET 5.0 and above, or in library code that is targeted to .NET Standard 2.1 and above.
 * .NET Standard 2.0: runs in .NET Framework 4.6.1 and above, or in library code that is targeted to .NET Standard 2.0.
 
 The .NET build tools should automatically load the most appropriate build of the library for whatever platform your application or library is targeted to.
+
+The 3.x version of `LaunchDarkly.Logging.Microsoft` is for use with `Microsoft.Extensions.Logging` version 6.x, and is functionally identical otherwise.
 
 The 2.x version of `LaunchDarkly.Logging.Microsoft` is for use with `Microsoft.Extensions.Logging` version 5.x, and is functionally identical otherwise.
 

--- a/src/LaunchDarkly.Logging.Microsoft/LaunchDarkly.Logging.Microsoft.csproj
+++ b/src/LaunchDarkly.Logging.Microsoft/LaunchDarkly.Logging.Microsoft.csproj
@@ -29,7 +29,7 @@
 
   <ItemGroup>
     <PackageReference Include="LaunchDarkly.Logging" Version="[1.0.1,]" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="[6.0.0,7.0.0)" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="[7.0.0,8.0.0)" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">

--- a/src/LaunchDarkly.Logging.Microsoft/LdMicrosoftLogging.cs
+++ b/src/LaunchDarkly.Logging.Microsoft/LdMicrosoftLogging.cs
@@ -18,7 +18,7 @@ namespace LaunchDarkly.Logging
         /// framework. The <c>ILoggerFactory</c> is the main configuration object for
         /// <c>Microsoft.Extensions.Logging</c>; application code can construct it programmatically,
         /// or can obtain it by dependency injection. For more information, see
-        /// <see href="https://docs.microsoft.com/en-us/aspnet/core/fundamentals/logging/?view=aspnetcore-3.1">Logging
+        /// <see href="https://learn.microsoft.com/en-us/aspnet/core/fundamentals/logging/?view=aspnetcore-7.0">Logging
         /// in .NET Core and ASP.NET Core</see>.
         /// </para>
         /// <para>
@@ -45,7 +45,7 @@ namespace LaunchDarkly.Logging
 
         public IChannel NewChannel(string name) =>
             new ChannelImpl(_factory.CreateLogger(name));
-   
+
         private class ChannelImpl : IChannel
         {
             private readonly ILogger _logger;

--- a/test/LaunchDarkly.Logging.Microsoft.Tests/LaunchDarkly.Logging.Microsoft.Tests.csproj
+++ b/test/LaunchDarkly.Logging.Microsoft.Tests/LaunchDarkly.Logging.Microsoft.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TestFramework Condition="'$(TESTFRAMEWORK)' == ''">netcoreapp2.1;net5.0</TestFramework>
+    <TestFramework Condition="'$(TESTFRAMEWORK)' == ''">net7.0</TestFramework>
     <TargetFrameworks>$(TESTFRAMEWORK)</TargetFrameworks>
     <AssemblyName>LaunchDarkly.Logging.Microsoft.Tests</AssemblyName>
   </PropertyGroup>


### PR DESCRIPTION
Upgrading to allow use with Microsoft.Logging.Extensions v7.

Removing references to the older .NET Core versions as well, as they've fallen out of support and seemingly aren't supported by v7 of the logging library.

I've done my best to clear up any older references - please let me know what else might need doing, or if I've been too eager in cleaning some parts up!