### PR TITLE
feat: Update to support Microsoft.Logging.Extensions from .Net 9.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,15 +15,15 @@ jobs:
     strategy:
       matrix:
           os: ['ubuntu-latest', 'windows-latest']
-          dotnet: [{sdk: '7.x', test-framework: 'net7.0'}, {sdk: '6.x', test-framework: 'net6.0'}]
+          dotnet: [{sdk: '8.x', test-framework: 'net8.0'}, {sdk: '9.x', test-framework: 'net9.0'}]
     runs-on: ${{ matrix.os }}
     name: Build ${{ matrix.os }} - ${{ matrix.dotnet.sdk }} - ${{ matrix.dotnet.test-framework }}
     env:
       BUILDFRAMEWORKS: netstandard2.1
       TESTFRAMEWORK: ${{ matrix.dotnet.test-framework }}
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-dotnet@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: ${{ matrix.dotnet.sdk }}
       - run: dotnet restore src/LaunchDarkly.Logging.Microsoft

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the project will be documented in this file. For full release notes for the projects that depend on this project, see their respective changelogs. This file describes changes only to the common code. This project adheres to [Semantic Versioning](http://semver.org).
 
+## [3.2.0] - 2024-11-13
+### Changed:
+- Extended support of `Microsoft.Logging.Extensions` to include versions 9+.
+
 ## [3.1.0] - 2023-07-27
 ### Changed:
 - Extended support of `Microsoft.Logging.Extensions` to include versions 7 and 8. (Thanks [gizmohd](https://github.com/launchdarkly/dotnet-logging-adapter-ms/pull/13) and [dantdj](https://github.com/launchdarkly/dotnet-logging-adapter-ms/pull/9)!)

--- a/src/LaunchDarkly.Logging.Microsoft/LaunchDarkly.Logging.Microsoft.csproj
+++ b/src/LaunchDarkly.Logging.Microsoft/LaunchDarkly.Logging.Microsoft.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.1.0</Version>
+    <Version>3.2.0</Version>
     <!--
       The reason there's a mechanism here for overriding the target frameworks with
       an environment variable is that we want to be able to run CI tests using older
@@ -19,7 +19,7 @@
     <Company>LaunchDarkly</Company>
     <Authors>LaunchDarkly</Authors>
     <Owners>LaunchDarkly</Owners>
-    <Copyright>Copyright 2023 LaunchDarkly</Copyright>
+    <Copyright>Copyright 2024 LaunchDarkly</Copyright>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/launchdarkly/dotnet-logging-adapter-ms</PackageProjectUrl>
     <RepositoryUrl>https://github.com/launchdarkly/dotnet-logging-adapter-ms</RepositoryUrl>
@@ -29,7 +29,7 @@
 
   <ItemGroup>
     <PackageReference Include="LaunchDarkly.Logging" Version="[1.0.1,]" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="[6.0.0,9.0.0)" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="[6.0.0,)" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">

--- a/src/LaunchDarkly.Logging.Microsoft/LaunchDarkly.Logging.Microsoft.csproj
+++ b/src/LaunchDarkly.Logging.Microsoft/LaunchDarkly.Logging.Microsoft.csproj
@@ -29,7 +29,7 @@
 
   <ItemGroup>
     <PackageReference Include="LaunchDarkly.Logging" Version="[1.0.1,]" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="[6.0.0,)" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="[6.0.0,10.0.0)" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">

--- a/src/LaunchDarkly.Logging.Microsoft/LaunchDarkly.Logging.Microsoft.csproj
+++ b/src/LaunchDarkly.Logging.Microsoft/LaunchDarkly.Logging.Microsoft.csproj
@@ -19,7 +19,7 @@
     <Company>LaunchDarkly</Company>
     <Authors>LaunchDarkly</Authors>
     <Owners>LaunchDarkly</Owners>
-    <Copyright>Copyright 2024 LaunchDarkly</Copyright>
+    <Copyright>Copyright 2023 LaunchDarkly</Copyright>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/launchdarkly/dotnet-logging-adapter-ms</PackageProjectUrl>
     <RepositoryUrl>https://github.com/launchdarkly/dotnet-logging-adapter-ms</RepositoryUrl>

--- a/test/LaunchDarkly.Logging.Microsoft.Tests/LaunchDarkly.Logging.Microsoft.Tests.csproj
+++ b/test/LaunchDarkly.Logging.Microsoft.Tests/LaunchDarkly.Logging.Microsoft.Tests.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TestFramework Condition="'$(TESTFRAMEWORK)' == ''">net6.0;net7.0</TestFramework>
+    <TestFramework Condition="'$(TESTFRAMEWORK)' == ''">net8.0;net9.0</TestFramework>
     <TargetFrameworks>$(TESTFRAMEWORK)</TargetFrameworks>
     <AssemblyName>LaunchDarkly.Logging.Microsoft.Tests</AssemblyName>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
-    <PackageReference Include="xunit" Version="2.5.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0"/>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2"/>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Closes #19 

Updates the `Microsoft.Extensions.Logging` dependency to accept 9.x versions.

.NET 9 was officially released yesterday. Support for .NET 6 also ended yesterday.

I am not sure what to do about this file https://github.com/launchdarkly/dotnet-logging-adapter-ms/blob/main/.ldrelease/config.yml, as it seems to be a custom Launch Darkly build container. 

I inspected the `ldcircleci/dotnet6-release:1` container image, and it appears to just be the .NET 6 SDK with the `osslsigncode` binary included, but I am unfamiliar with this. Unclear if a dotnet8 version needs to be created, or if the official `mcr.microsoft.com/dotnet/sdk` image could be used.