### PR TITLE
chg: update to support Microsoft.Extensions.Logging from .NET 10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,16 @@ jobs:
   build-test-linux:
     strategy:
       matrix:
-          os: ['ubuntu-latest', 'windows-latest']
-          dotnet: [{sdk: '8.x', test-framework: 'net8.0'}, {sdk: '9.x', test-framework: 'net9.0'}]
+        os:
+          - ubuntu-latest
+          - windows-latest
+        dotnet:
+          - sdk: '8.x'
+            test-framework: 'net8.0'
+          - sdk: '9.x'
+            test-framework: 'net9.0'
+          - sdk: '10.x'
+            test-framework: 'net10.0'
     runs-on: ${{ matrix.os }}
     name: Build ${{ matrix.os }} - ${{ matrix.dotnet.sdk }} - ${{ matrix.dotnet.test-framework }}
     env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 All notable changes to the project will be documented in this file. For full release notes for the projects that depend on this project, see their respective changelogs. This file describes changes only to the common code. This project adheres to [Semantic Versioning](http://semver.org).
 
-## [3.3.0] - 2025-11-11
-### Changed:
-- Extended support of `Microsoft.Logging.Extensions` to include versions 10+.
-
 ## [3.2.0](https://github.com/launchdarkly/dotnet-logging-adapter-ms/compare/3.1.0...v3.2.0) (2024-11-19)
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,11 @@
 
 All notable changes to the project will be documented in this file. For full release notes for the projects that depend on this project, see their respective changelogs. This file describes changes only to the common code. This project adheres to [Semantic Versioning](http://semver.org).
 
-## [3.2.0](https://github.com/launchdarkly/dotnet-logging-adapter-ms/compare/3.1.0...v3.2.0) (2024-11-19)
+## [3.3.0] - 2025-11-11
+### Changed:
+- Extended support of `Microsoft.Logging.Extensions` to include versions 10+.
 
+## [3.2.0](https://github.com/launchdarkly/dotnet-logging-adapter-ms/compare/3.1.0...v3.2.0) (2024-11-19)
 
 ### Features
 

--- a/src/LaunchDarkly.Logging.Microsoft/LaunchDarkly.Logging.Microsoft.csproj
+++ b/src/LaunchDarkly.Logging.Microsoft/LaunchDarkly.Logging.Microsoft.csproj
@@ -29,7 +29,7 @@
 
   <ItemGroup>
     <PackageReference Include="LaunchDarkly.Logging" Version="[1.0.1,]" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="[6.0.0,10.0.0)" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="[6.0.0,11.0.0)" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">


### PR DESCRIPTION
Relaxes the dependency constraint of the library to support .NET 10 versions of Microsoft.Extensions.Logging
Adds testing coverage for .NET 10

BEGIN_COMMIT_OVERRIDE
feat: Update Microsoft.Extensions.Logging version constraint to include 10.x.
END_COMMIT_OVERRIDE