### PR TITLE
ci: switch to actions/attest for provenance

### DIFF
--- a/.github/actions/publish/action.yml
+++ b/.github/actions/publish/action.yml
@@ -4,11 +4,6 @@ inputs:
   dry_run:
     description: 'Is this a dry run. If so no package will be published.'
     required: true
-outputs:
-  hashes:
-    description: sha256sum hashes of built artifacts
-    value: ${{ steps.hash.outputs.hashes }}
-
 runs:
   using: composite
   steps:
@@ -32,13 +27,6 @@ runs:
           dotnet nuget push "${pkg}" --api-key ${{ env.NUGET_API_KEY }} --source https://www.nuget.org
           echo "published ${pkg}"
         done
-
-    - name: Hash nuget packages
-      id: hash
-      if: ${{ inputs.dry_run == 'false' }}
-      shell: bash
-      run: |
-        echo "hashes=$(sha256sum ./nupkgs/*.nupkg ./nupkgs/*.snupkg | base64 -w0)" >> "$GITHUB_OUTPUT"
 
     - name: Dry Run Publish
       if: ${{ inputs.dry_run == 'true' }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -71,15 +71,8 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           dry_run: ${{ inputs.dry_run }}
 
-      - name: Generate checksums file
-        if: ${{ inputs.dry_run == 'false' }}
-        env:
-          HASHES: ${{ steps.publish.outputs.hashes }}
-        run: |
-          echo "$HASHES" | base64 -d > checksums.txt
-
       - name: Attest build provenance
         if: ${{ inputs.dry_run == 'false' }}
         uses: actions/attest@v4
         with:
-          subject-checksums: checksums.txt
+          subject-path: 'nupkgs/*'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -64,7 +64,7 @@ jobs:
           dry_run: ${{ inputs.dry_run }}
 
       - name: Attest build provenance
-        if: ${{ inputs.dry_run == 'false' }}
+        if: ${{ format('{0}', inputs.dry_run) == 'false' }}
         uses: actions/attest@v4
         with:
           subject-path: 'nupkgs/*'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,9 +8,14 @@ on:
         type: boolean
         required: true
       tag:
-        description: 'Tag for provenance. For a dry run the value does not matter.'
+        description: 'Tag of an existing draft release. For a dry run the value does not matter.'
         type: string
         required: true
+      publish_release:
+        description: 'Publish (un-draft) the release after all artifacts are uploaded?'
+        type: boolean
+        required: false
+        default: true
 
   workflow_call:
     inputs:
@@ -22,6 +27,11 @@ on:
         description: 'Tag for provenance'
         type: string
         required: true
+      publish_release:
+        description: 'Publish (un-draft) the release after all artifacts are uploaded?'
+        type: boolean
+        required: false
+        default: false
 
 jobs:
   publish:
@@ -84,3 +94,19 @@ jobs:
         uses: actions/attest@v4
         with:
           subject-checksums: checksums.txt
+
+  publish-release:
+    needs: ['publish']
+    if: ${{ !inputs.dry_run && inputs.publish_release }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Publish release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ inputs.tag }}
+        run: >
+          gh release edit "$TAG_NAME"
+          --repo ${{ github.repository }}
+          --draft=false

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,20 +7,12 @@ on:
         description: 'Is this a dry run. If so no package will be published.'
         type: boolean
         required: true
-      tag:
-        description: 'Tag for provenance. For a dry run the value does not matter.'
-        type: string
-        required: true
 
   workflow_call:
     inputs:
       dry_run:
         description: 'Is this a dry run. If so no package will be published.'
         type: boolean
-        required: true
-      tag:
-        description: 'Tag for provenance'
-        type: string
         required: true
 
 jobs:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,14 +8,9 @@ on:
         type: boolean
         required: true
       tag:
-        description: 'Tag of an existing draft release. For a dry run the value does not matter.'
+        description: 'Tag for provenance. For a dry run the value does not matter.'
         type: string
         required: true
-      publish_release:
-        description: 'Publish (un-draft) the release after all artifacts are uploaded?'
-        type: boolean
-        required: false
-        default: true
 
   workflow_call:
     inputs:
@@ -27,11 +22,6 @@ on:
         description: 'Tag for provenance'
         type: string
         required: true
-      publish_release:
-        description: 'Publish (un-draft) the release after all artifacts are uploaded?'
-        type: boolean
-        required: false
-        default: false
 
 jobs:
   publish:
@@ -56,7 +46,6 @@ jobs:
             /production/common/releasing/digicert/code_signing_cert_sha1_hash = DIGICERT_CODE_SIGNING_CERT_SHA1_HASH,
             /production/common/releasing/nuget/api_key = NUGET_API_KEY'
           s3_path_pairs: 'launchdarkly-releaser/dotnet/LaunchDarkly.Logging.snk = LaunchDarkly.Logging.snk'
-
 
       - name: Build Release
         uses: ./.github/actions/release-build
@@ -94,19 +83,3 @@ jobs:
         uses: actions/attest@v4
         with:
           subject-checksums: checksums.txt
-
-  publish-release:
-    needs: ['publish']
-    if: ${{ !inputs.dry_run && inputs.publish_release }}
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - name: Publish release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG_NAME: ${{ inputs.tag }}
-        run: >
-          gh release edit "$TAG_NAME"
-          --repo ${{ github.repository }}
-          --draft=false

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,6 +30,7 @@ jobs:
       id-token: write # Needed if using OIDC to get release secrets.
       contents: write # Contents and pull-requests are for release-please to make releases.
       pull-requests: write
+      attestations: write
 
     steps:
       - uses: actions/checkout@v4
@@ -71,16 +72,15 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           dry_run: ${{ inputs.dry_run }}
 
-  provenance:
-    permissions:
-      actions: read
-      id-token: write
-      contents: write
-    if: ${{ inputs.dry_run  == 'false' }}
-    needs: ['publish']
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.10.0
-    with:
-      base64-subjects: "${{ needs.publish.outputs.hashes }}"
-      upload-assets: true
-      upload-tag-name: ${{ inputs.tag }}
-      provenance-name: ${{ format('LaunchDarkly.Logging.Microsoft-{0}_provenance.intoto.jsonl', inputs.tag) }}
+      - name: Generate checksums file
+        if: ${{ inputs.dry_run == 'false' }}
+        env:
+          HASHES: ${{ steps.publish.outputs.hashes }}
+        run: |
+          echo "$HASHES" | base64 -d > checksums.txt
+
+      - name: Attest build provenance
+        if: ${{ inputs.dry_run == 'false' }}
+        uses: actions/attest@v4
+        with:
+          subject-checksums: checksums.txt

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -9,7 +9,6 @@ jobs:
   release-please:
     outputs:
       release_created: ${{ steps.release.outputs.releases_created }}
-      tag_name: ${{ steps.release.outputs.tag_name }}
     runs-on: ubuntu-latest
     permissions:
       id-token: write # Needed if using OIDC to get release secrets.

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   release-please:
     outputs:
-      releases_created: ${{ steps.release.outputs.releases_created }}
+      release_created: ${{ steps.release.outputs.releases_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
     runs-on: ubuntu-latest
     permissions:
@@ -24,14 +24,57 @@ jobs:
           token: ${{secrets.GITHUB_TOKEN}}
           default-branch: main
 
+  create-tag:
+    needs: ['release-please']
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Create release tag
+        env:
+          TAG_NAME: ${{ needs.release-please.outputs.tag_name }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh api "repos/${{ github.repository }}/git/ref/tags/${TAG_NAME}" >/dev/null 2>&1; then
+            echo "Tag ${TAG_NAME} already exists, skipping creation."
+          else
+            echo "Creating tag ${TAG_NAME}."
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git tag "${TAG_NAME}"
+            git push origin "${TAG_NAME}"
+          fi
+
   ci:
     needs: ['release-please']
-    if: ${{ needs.release-please.outputs.releases_created == 'true' }}
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
     uses: ./.github/workflows/ci.yml
+
   publish:
-    needs: ['release-please']
-    if: ${{ needs.release-please.outputs.releases_created == 'true' }}
+    needs: ['release-please', 'create-tag']
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
     uses: ./.github/workflows/publish.yml
     with:
       dry_run: false
       tag: ${{ needs.release-please.outputs.tag_name }}
+
+  publish-release:
+    needs: ['release-please', 'publish']
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Publish release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ needs.release-please.outputs.tag_name }}
+        run: >
+          gh release edit "$TAG_NAME"
+          --repo ${{ github.repository }}
+          --draft=false

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -24,57 +24,15 @@ jobs:
           token: ${{secrets.GITHUB_TOKEN}}
           default-branch: main
 
-  create-tag:
-    needs: ['release-please']
-    if: ${{ needs.release-please.outputs.release_created == 'true' }}
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Create release tag
-        env:
-          TAG_NAME: ${{ needs.release-please.outputs.tag_name }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          if gh api "repos/${{ github.repository }}/git/ref/tags/${TAG_NAME}" >/dev/null 2>&1; then
-            echo "Tag ${TAG_NAME} already exists, skipping creation."
-          else
-            echo "Creating tag ${TAG_NAME}."
-            git config user.name "github-actions[bot]"
-            git config user.email "github-actions[bot]@users.noreply.github.com"
-            git tag "${TAG_NAME}"
-            git push origin "${TAG_NAME}"
-          fi
-
   ci:
     needs: ['release-please']
     if: ${{ needs.release-please.outputs.release_created == 'true' }}
     uses: ./.github/workflows/ci.yml
 
   publish:
-    needs: ['release-please', 'create-tag']
+    needs: ['release-please']
     if: ${{ needs.release-please.outputs.release_created == 'true' }}
     uses: ./.github/workflows/publish.yml
     with:
       dry_run: false
       tag: ${{ needs.release-please.outputs.tag_name }}
-
-  publish-release:
-    needs: ['release-please', 'publish']
-    if: ${{ needs.release-please.outputs.release_created == 'true' }}
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - name: Publish release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG_NAME: ${{ needs.release-please.outputs.tag_name }}
-        run: >
-          gh release edit "$TAG_NAME"
-          --repo ${{ github.repository }}
-          --draft=false

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -35,4 +35,3 @@ jobs:
     uses: ./.github/workflows/publish.yml
     with:
       dry_run: false
-      tag: ${{ needs.release-please.outputs.tag_name }}

--- a/PROVENANCE.md
+++ b/PROVENANCE.md
@@ -1,0 +1,49 @@
+## Verifying SDK build provenance with GitHub artifact attestations
+
+LaunchDarkly uses [GitHub artifact attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published SDK packages.
+
+LaunchDarkly publishes provenance about our SDK package builds using [GitHub's `actions/attest` action](https://github.com/actions/attest). These attestations are stored in GitHub's attestation API and can be verified using the [GitHub CLI](https://cli.github.com/).
+
+To verify build provenance attestations, we recommend using the [GitHub CLI `attestation verify` command](https://cli.github.com/manual/gh_attestation_verify). Example usage for verifying SDK packages is included below:
+
+<!-- x-release-please-start-version -->
+```
+# Set the version of the SDK to verify
+SDK_VERSION=3.3.0
+```
+<!-- x-release-please-end -->
+
+```
+# Download the nupkg from NuGet
+$ nuget install LaunchDarkly.Logging.Microsoft -Version $SDK_VERSION -OutputDirectory ./packages
+
+# Verify provenance using the GitHub CLI
+$ gh attestation verify ./packages/LaunchDarkly.Logging.Microsoft.${SDK_VERSION}/LaunchDarkly.Logging.Microsoft.${SDK_VERSION}.nupkg --owner launchdarkly
+```
+
+Below is a sample of expected output.
+
+```
+Loaded digest sha256:... for file://LaunchDarkly.Logging.Microsoft.3.3.0.nupkg
+Loaded 1 attestation from GitHub API
+
+The following policy criteria will be enforced:
+- Predicate type must match:................ https://slsa.dev/provenance/v1
+- Source Repository Owner URI must match:... https://github.com/launchdarkly
+- Subject Alternative Name must match regex: (?i)^https://github.com/launchdarkly/
+- OIDC Issuer must match:................... https://token.actions.githubusercontent.com
+
+✓ Verification succeeded!
+
+The following 1 attestation matched the policy criteria
+
+- Attestation #1
+  - Build repo:..... launchdarkly/dotnet-logging-adapter-ms
+  - Build workflow:. .github/workflows/release-please.yml
+  - Signer repo:.... launchdarkly/dotnet-logging-adapter-ms
+  - Signer workflow: .github/workflows/release-please.yml
+```
+
+For more information, see [GitHub's documentation on verifying artifact attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds#verifying-artifact-attestations-with-the-github-cli).
+
+**Note:** These instructions do not apply when building our SDKs from source.

--- a/README.md
+++ b/README.md
@@ -42,13 +42,17 @@ a8a17f69f1bef56e253fc9166096c907514ab74b812d041faa04712e2bcb243d
 Public Key Token: d9182e4b0afd33e7
 ```
 
+## Verifying build provenance with the SLSA framework
+
+LaunchDarkly uses the [SLSA framework](https://slsa.dev/spec/v1.0/about) (Supply-chain Levels for Software Artifacts) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published packages. To learn more, see the [provenance guide](PROVENANCE.md).
+
 ## About LaunchDarkly
  
 * LaunchDarkly is a continuous delivery platform that provides feature flags as a service and allows developers to iterate quickly and safely. We allow you to easily flag your features and manage them from the LaunchDarkly dashboard.  With LaunchDarkly, you can:
     * Roll out a new feature to a subset of your users (like a group of users who opt-in to a beta tester group), gathering feedback and bug reports from real-world use cases.
     * Gradually roll out a feature to an increasing percentage of users, and track the effect that the feature has on key metrics (for instance, how likely is a user to complete a purchase if they have feature A versus feature B?).
     * Turn off a feature that you realize is causing performance problems in production, without needing to re-deploy, or even restart the application with a changed configuration file.
-    * Grant access to certain features based on user attributes, like payment plan (eg: users on the ‘gold’ plan get access to more features than users in the ‘silver’ plan). Disable parts of your application to facilitate maintenance, without taking everything offline.
+    * Grant access to certain features based on user attributes, like payment plan (eg: users on the 'gold' plan get access to more features than users in the 'silver' plan). Disable parts of your application to facilitate maintenance, without taking everything offline.
 * LaunchDarkly provides feature flag SDKs for a wide variety of languages and technologies. Check out [our documentation](https://docs.launchdarkly.com/docs) for a complete list.
 * Explore LaunchDarkly
     * [launchdarkly.com](https://www.launchdarkly.com/ "LaunchDarkly Main Website") for more information

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,7 +2,6 @@
   "packages": {
     ".": {
       "release-type": "simple",
-      "force-tag-creation": true,
       "bootstrap-sha": "676c5a4b3763706c669c43117db19af8c5aeb80c",
       "extra-files": [
         "src/LaunchDarkly.Logging.Microsoft/LaunchDarkly.Logging.Microsoft.csproj"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,6 +2,7 @@
   "packages": {
     ".": {
       "release-type": "simple",
+      "draft": true,
       "bootstrap-sha": "676c5a4b3763706c669c43117db19af8c5aeb80c",
       "extra-files": [
         "src/LaunchDarkly.Logging.Microsoft/LaunchDarkly.Logging.Microsoft.csproj"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,7 +4,8 @@
       "release-type": "simple",
       "bootstrap-sha": "676c5a4b3763706c669c43117db19af8c5aeb80c",
       "extra-files": [
-        "src/LaunchDarkly.Logging.Microsoft/LaunchDarkly.Logging.Microsoft.csproj"
+        "src/LaunchDarkly.Logging.Microsoft/LaunchDarkly.Logging.Microsoft.csproj",
+        "PROVENANCE.md"
       ]
     }
   }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,6 +3,7 @@
     ".": {
       "release-type": "simple",
       "draft": true,
+      "force-tag-creation": true,
       "bootstrap-sha": "676c5a4b3763706c669c43117db19af8c5aeb80c",
       "extra-files": [
         "src/LaunchDarkly.Logging.Microsoft/LaunchDarkly.Logging.Microsoft.csproj"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,7 +2,6 @@
   "packages": {
     ".": {
       "release-type": "simple",
-      "draft": true,
       "force-tag-creation": true,
       "bootstrap-sha": "676c5a4b3763706c669c43117db19af8c5aeb80c",
       "extra-files": [


### PR DESCRIPTION
## Summary

Migrates the release workflow to support GitHub's immutable releases feature. Since this repo only uses attestation (no artifact uploads to the release), draft releases are **not** needed — `actions/attest@v4` stores attestations via GitHub's attestation API, not as release assets.

**Changes:**

1. **`.github/actions/publish/action.yml`** — Removed the `hashes` output and the "Hash nuget packages" step. These existed to produce base64-encoded checksums for the old SLSA generator and are no longer needed since attestation now uses `subject-path` to reference artifacts directly on disk.
2. **`.github/workflows/release-please.yml`** — Renamed job output key from `releases_created` to `release_created` (singular); updated downstream `if` conditions accordingly. Removed `tag_name` output (dead code — no remaining consumers). Removed `tag` from the `publish` workflow call since it is no longer an input.
3. **`.github/workflows/publish.yml`** — Replaced the separate `provenance` job (SLSA `generator_generic_slsa3` reusable workflow with `upload-assets: true` and `base64-subjects`) with an inline `actions/attest@v4` step using `subject-path: 'nupkgs/*'`. Added `attestations: write` permission. Removed the unused `tag` input from both `workflow_dispatch` and `workflow_call` triggers. The dry-run guard uses `format('{0}', inputs.dry_run) == 'false'` to handle both `workflow_dispatch` (string) and `workflow_call` (boolean) trigger types correctly.
4. **`PROVENANCE.md`** *(new)* — Documents how to verify build provenance using `gh attestation verify`, with example commands for downloading the NuGet package and sample verification output.
5. **`README.md`** — Added a "Verifying build provenance with the SLSA framework" section linking to `PROVENANCE.md`. Minor trailing-whitespace fix on an unrelated line (no content change).

Because `actions/attest@v4` does not upload anything to the GitHub release (unlike the old SLSA generator which uploaded `.intoto.jsonl` files), there is no need for draft releases, create-tag jobs, or publish-release jobs.

### Updates since last revision

- Reverted the split release-please pattern (two-pass `skip-github-pull-request` / `skip-github-release`) that was briefly added. This pattern is only needed for repos that upload artifacts to releases and require draft releases. Since this repo is attestation-only, the standard single-pass release-please is correct.

## Review & Testing Checklist for Human

- [ ] **Verify the `release_created` output rename is safe**: The job-level output key was renamed from `releases_created` to `release_created` (singular). The value still maps from `steps.release.outputs.releases_created` (plural, from the release-please action). Confirm no other workflows or external callers reference `needs.release-please.outputs.releases_created` (the old key name). Note: Bugbot flagged that in manifest mode, the aggregate output is `releases_created` (plural) — confirm this repo uses simple mode or that the singular output is also emitted in manifest mode.
- [ ] **Verify `subject-path: 'nupkgs/*'` matches build output**: The composite action runs `dotnet pack --output nupkgs`, so `.nupkg` and `.snupkg` files should land in `./nupkgs/`. Confirm this glob resolves correctly from the workflow's working directory. The step is gated on dry-run so an empty directory during dry runs is expected.
- [ ] **Verify nothing else consumes the removed `tag` input, `tag_name` output, or `hashes` output**: These were only used by the deleted SLSA provenance job. Confirm no external workflows or callers depend on them.
- [ ] **Test plan**: Trigger a dry-run publish to verify YAML validity (attestation step should be skipped via the `format()` condition). Then trigger a real release to confirm the full flow: release creation → publish → attest. After the release, verify the attestation is stored via `gh attestation verify` and that no `.intoto.jsonl` asset appears on the release.

### Notes
- The `attestations: write` permission was added to the `publish` job to support `actions/attest@v4`.
- The old SLSA generator uploaded a `.intoto.jsonl` provenance file as a release asset. Confirm no downstream consumers depend on that file — attestations are now stored via GitHub's attestation API instead.
- The `format('{0}', inputs.dry_run) == 'false'` pattern stringifies the input regardless of source type, ensuring the comparison works for both `workflow_call` (boolean) and `workflow_dispatch` (string) triggers.
- No `draft` or `force-tag-creation` settings are added to `release-please-config.json` — these are only needed for repos that upload artifacts to releases.

Link to Devin session: https://app.devin.ai/sessions/7d5bda4d9dbe4ae0b950b30a50485e60
Requested by: @keelerm84