### PR TITLE
ci: split release-please into independent release and PR creation steps

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   release-please:
     outputs:
-      release_created: ${{ steps.release.outputs.releases_created }}
+      release_created: ${{ steps.release.outputs.release_created }}
     runs-on: ubuntu-latest
     permissions:
       id-token: write # Needed if using OIDC to get release secrets.

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,12 +16,43 @@ jobs:
       pull-requests: write
 
     steps:
+      # Create any releases first, then create tags, and then optionally create any new PRs.
       - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4.4.0
         id: release
         with:
           command: manifest
           token: ${{secrets.GITHUB_TOKEN}}
           default-branch: main
+          skip-github-pull-request: true
+
+      # Need the repository content to be able to create and push a tag.
+      - uses: actions/checkout@v4
+        if: ${{ steps.release.outputs.release_created == 'true' }}
+
+      - name: Create release tag
+        if: ${{ steps.release.outputs.release_created == 'true' }}
+        env:
+          TAG_NAME: ${{ steps.release.outputs.tag_name }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh api "repos/${{ github.repository }}/git/ref/tags/${TAG_NAME}" >/dev/null 2>&1; then
+            echo "Tag ${TAG_NAME} already exists, skipping creation."
+          else
+            echo "Creating tag ${TAG_NAME}."
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git tag "${TAG_NAME}"
+            git push origin "${TAG_NAME}"
+          fi
+
+      - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4.4.0
+        if: ${{ steps.release.outputs.release_created != 'true' }}
+        id: release-prs
+        with:
+          command: manifest
+          token: ${{secrets.GITHUB_TOKEN}}
+          default-branch: main
+          skip-github-release: true
 
   ci:
     needs: ['release-please']


### PR DESCRIPTION
## Summary

Splits the single `release-please-action` call into two independent passes to support GitHub's immutable releases:

1. **First pass** (`skip-github-pull-request: true`): Creates releases only. If a release is created, the tag is explicitly created and pushed before proceeding.
2. **Second pass** (`skip-github-release: true`, only if no release was created): Creates or updates release PRs.

This ensures the tag exists before release-please evaluates whether a new release PR is needed. Without this split, release-please may create a duplicate release PR because it runs before the tag is available.

Pattern matches the reference implementation in [ld-relay PR #622](https://github.com/launchdarkly/ld-relay/pull/622).

## Review & Testing Checklist for Human

- [ ] Verify that the job output `release_created: ${{ steps.release.outputs.releases_created }}` (plural) is still correctly populated by the first release-please call (the one with `skip-github-pull-request: true`) — downstream `ci` and `publish` jobs depend on this
- [ ] Confirm the tag-creation condition uses `release_created` (singular) from `steps.release.outputs` which is correct for this single-package repo
- [ ] Test by merging a release-please PR and confirming: (a) the release is created, (b) the tag is pushed, and (c) no duplicate release PR is opened afterward

### Notes
- The `command: manifest` and `default-branch: main` parameters are preserved on both release-please calls
- Tag name is passed via `env` (not inline expansion) to avoid script injection
- Tag creation is idempotent — checks for existing tag via `gh api` before attempting to create

Link to Devin session: https://app.devin.ai/sessions/7d5bda4d9dbe4ae0b950b30a50485e60
Requested by: @keelerm84

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the release automation flow and adds manual tag creation/push logic, which could affect whether releases/PRs are created and whether downstream `ci`/`publish` jobs run.
> 
> **Overview**
> Updates the `Release Please` GitHub Actions workflow to **split release creation from release-PR creation**.
> 
> The first `release-please-action` run now creates releases only (skipping PRs), then conditionally checks out the repo and **creates/pushes the release tag** (idempotently) when a release was created. If no release was created, a second `release-please-action` run executes in PR-only mode (skipping GitHub releases).
> 
> Fixes the job output wiring to use `steps.release.outputs.release_created` so downstream `ci`/`publish` jobs continue to gate on whether a release was produced.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c32edb2cdcf01959e50e4fcd24ab49d698359d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->